### PR TITLE
Update AnyWriter to support writers that expect a mutable self

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -19,7 +19,7 @@ pub fn build(b: *std.Build) void {
 
     const ego = b.addModule("ego", .{
         .source_file = std.Build.FileSource.relative("./src/ego.zig"),
-        .dependencies = &.{},
+        .dependencies = &.{.{ .name = "zcon", .module = zcon }},
     });
 
     // -- examples

--- a/examples/bench.zig
+++ b/examples/bench.zig
@@ -115,11 +115,10 @@ const Trace = struct {
             if (out_file) |of|
                 out_file_writer = of.writer();
         }
-        const out_writer = if (out_file) |of|
-            of.writer()
+        const out = if (out_file_writer) |*ofw|
+            AnyWriter.init(ofw)
         else
-            std.io.getStdOut().writer();
-        const out = AnyWriter.init(&out_writer);
+            AnyWriter.init(writer);
 
         // set up debug trace
         ego.debugtrace.setOutWriter(out);


### PR DESCRIPTION
Update `AnyWriter` to support writers that expect a mutable self